### PR TITLE
Feature / Add option to internalise git conflicts when editing credentials

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `--internalise-conflicts` options to the `rails credentails edit` commans
+
+    *SixiS*
+
 *   Remove unnecessary `ruby-version` input from `ruby/setup-ruby`
 
     *TangRufus*

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -55,6 +55,11 @@ Editing Credentials:
     `config/credentials.yml.enc` while the file itself is destroyed to prevent credentials
     from leaking.
 
+    If there are git rebase or merge conflits on the credentials file,
+    you can use the `--internalise-conflicts` option on edit
+    to internalise the conflicts into the credentials file
+    so you can edit them.
+
 Environment Specific Credentials:
     The `credentials` command supports passing an `--environment` option to create an
     environment specific override. That override will take precedence over the

--- a/railties/lib/rails/commands/credentials/credentials_command/conflicted_credentials.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command/conflicted_credentials.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+module Rails
+  module Command
+    class CredentialsCommand
+      class ConflictedCredentials
+        GIT_CONFLICT_MARKER = /^<{7} (?:(?!={7})[\s\S])*={7}(?:(?!>{7} \w+)[\s\S])*>{7} .+/
+
+        def initialize(content_path, key_path)
+          @content_path = content_path
+          @key_path = key_path
+          return if content_path.blank? || !File.exist?(content_path)
+
+          @file_data = File.binread(content_path).strip
+        end
+
+        def conflicts?
+          return false if @file_data.nil?
+
+          @file_data.match?(GIT_CONFLICT_MARKER)
+        end
+
+        def internalise_conflicts
+          left_unencrypted_string, right_unencrypted_string = decrypt_individual_files
+          return if right_unencrypted_string.nil?
+
+          conflicted_unencrypted_string = merge_conflicted_strings(
+            left_unencrypted_string,
+            right_unencrypted_string
+          )
+
+          ActiveSupport::EncryptedFile.new(
+            content_path: @content_path,
+            key_path: @key_path,
+            env_key: "RAILS_MASTER_KEY",
+            raise_if_missing_key: true
+          ).write(conflicted_unencrypted_string)
+        end
+
+        private
+          def decrypt_individual_files
+            left_encrypted_string, right_encrypted_string = split_conflict(@file_data)
+            return nil if right_encrypted_string.nil?
+
+            left_encrypted_file = Tempfile.new("encrypted-left")
+            left_encrypted_file.write(left_encrypted_string)
+            left_encrypted_file.close
+
+            right_encrypted_file = Tempfile.new("encrypted-right")
+            right_encrypted_file.write(right_encrypted_string)
+            right_encrypted_file.close
+
+            unencrypted_left_string = ActiveSupport::EncryptedFile.new(
+              content_path: left_encrypted_file.path,
+              key_path: @key_path,
+              env_key: "RAILS_MASTER_KEY",
+              raise_if_missing_key: true
+            ).read
+
+            unencrypted_right_string = ActiveSupport::EncryptedFile.new(
+              content_path: right_encrypted_file.path,
+              key_path: @key_path,
+              env_key: "RAILS_MASTER_KEY",
+              raise_if_missing_key: true
+            ).read
+
+            [unencrypted_left_string, unencrypted_right_string]
+          ensure
+            [left_encrypted_file, right_encrypted_file].each do |f|
+              f.unlink if f&.path && File.exist?(f.path)
+            end
+          end
+
+          def split_conflict(content)
+            if content.match?(GIT_CONFLICT_MARKER)
+              @conflict_type = :git
+              split_git_conflict(content)
+            else
+              @conflict_type = :unknown
+              [content, nil]
+            end
+          end
+
+          def split_git_conflict(content)
+            left_lines = []
+            right_lines = []
+
+            state = :common
+            content.each_line do |line|
+              if line.start_with?("<<<<<<< ")
+                @head_left ||= line.split("<<<<<<< ").last.strip
+                state = :in_left
+              elsif line.start_with?("=======")
+                state = :in_right
+              elsif line.start_with?(">>>>>>> ")
+                @head_right ||= line.split(">>>>>>> ").last.strip
+                state = :common
+              elsif state == :in_left
+                left_lines << line
+              elsif state == :in_right
+                right_lines << line
+              else
+                left_lines << line
+                right_lines << line
+              end
+            end
+
+            [left_lines.join.strip, right_lines.join.strip]
+          end
+
+          def merge_conflicted_strings(left_string, right_string)
+            if @conflict_type == :git
+              git_merge_strings(left_string, right_string)
+            else
+              default_merge_strings(left_string, right_string)
+            end
+          end
+
+          def git_merge_strings(local_str, remote_str, base_str = "")
+            base_file = Tempfile.new("git-merge-base")
+            base_file.write(base_str)
+            base_file.close
+            local_file = Tempfile.new("git-merge-local")
+            local_file.write(local_str)
+            local_file.close
+            remote_file = Tempfile.new("git-merge-remote")
+            remote_file.write(remote_str)
+            remote_file.close
+
+            cmd = [
+              "git merge-file -p",
+              local_file.path,
+              base_file.path,
+              remote_file.path,
+              "2>&1"
+            ].join(" ")
+
+            merged = `#{cmd}`
+            status = $?
+
+            unless status.success? || status.exitstatus == 1
+              return default_merge_strings(local_str, remote_str)
+            end
+
+            merged.strip
+              .gsub(local_file.path, @head_left)
+              .gsub(remote_file.path, @head_right)
+          ensure
+            [base_file, local_file, remote_file].each do |f|
+              f.unlink if f&.path && File.exist?(f.path)
+            end
+          end
+
+          def default_merge_strings(local_str, remote_str)
+            [
+              "<<<<<<< #{@head_left}",
+              local_str,
+              "=======",
+              remote_str,
+              ">>>>>> #{@head_right}"
+            ].compact.join("\n")
+          end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because handling merge conflicts in the encrypted credentials files feels manual and difficult.

We do have the ability to make git diff work with the encrypted files via `rails credentials:diff --enroll` but that doesn't seem to help with merge or rebase conflicts.

Resolving the conflict is a manual process, pulling the conflicted filed apart, diff'ing them and then putting them back together.
We have the encrypted files in the diff, and we have the key, so we have everything we need to resolve the issue in an automated way.

Googling the issue also doesn't bring up much.
But there are few complaints that users expect the flow to be easier.

https://discuss.rubyonrails.org/t/editing-rails-credentials-when-theres-a-git-merge-conflict/81487

https://stackoverflow.com/questions/58980566/how-to-deal-with-merge-conflicts-in-rails-encrypted-credential-files

https://github.com/rails/rails/issues/44701

### Detail

This Pull Request add an `--internalise-conflicts` option to the `rails credentials edit` command.

This option decrypts both versions of the file in the conflict, uses git to combine them so the merge conflict is resolved or added to the unencrypted text, writes it to the encrypted file and then continues with the normal edit command flow.

### Additional information

-

### Checklist

Before submitting the PR make sure the following are checked:

* [✓] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [✓] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [✓] Tests are added or updated if you fix a bug or add a feature.
* [✓] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
